### PR TITLE
Modifying venue and address

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,8 +1,8 @@
 ---
 layout: workshop
 root: .
-venue: Science Library, University of Oslo 
-address: Moltke Moes Road 35, 0851 Oslo
+venue: University of Oslo 
+address: Science Library, Moltke Moes Road 35, 0851 Oslo
 country: Norway
 latlng: 59.94, 10.723
 humandate: Feb 26-27, 2015


### PR DESCRIPTION
We normally use just the institution name for 'venue', and put other information in 'address', so that the home page for software-carpentry.org will lay out nicely.
